### PR TITLE
no overrides, and null types

### DIFF
--- a/src/main/kotlin/com/karumi/weak/WeakReferenceDelegate.kt
+++ b/src/main/kotlin/com/karumi/weak/WeakReferenceDelegate.kt
@@ -3,20 +3,13 @@ package com.karumi.weak
 import java.lang.ref.WeakReference
 import kotlin.reflect.KProperty
 
-inline fun <reified T> weak() = WeakReferenceDelegate<T>()
+inline fun <reified T> weak(value: T? = null) = WeakReferenceDelegate(value)
 
-inline fun <reified T> weak(value: T) = WeakReferenceDelegate(value)
+class WeakReferenceDelegate<T>(v: T? = null) {
+    private var weakReference: WeakReference<T?> = WeakReference(v)
 
-class WeakReferenceDelegate<T> {
-    private var weakReference: WeakReference<T>? = null
-
-    constructor()
-    constructor(value: T) {
-        weakReference = WeakReference(value)
-    }
-
-    operator fun getValue(thisRef: Any, property: KProperty<*>): T? = weakReference?.get()
-    operator fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+    operator fun getValue(thisRef: Any, property: KProperty<*>): T? = weakReference.get()
+    operator fun setValue(thisRef: Any, property: KProperty<*>, value: T?) {
         weakReference = WeakReference(value)
     }
 }


### PR DESCRIPTION
With parameter defaulting to null, overrides aren't needed, neither of the inline fun nor of the constructor. Also, since weak references could always return null, their generic type should always be nullable.